### PR TITLE
Have perl and python print their own versions

### DIFF
--- a/checkrebuild
+++ b/checkrebuild
@@ -16,13 +16,13 @@ get_broken_ldd_pkgs() {
 
 get_broken_python_pkgs() {
     command -v python >/dev/null || return
-    python_version="$(python --version | cut -d'.' -f2)"
+    python_version="$(python3 -c 'import sys; print (sys.version_info.minor)')"
     pacman -Qqo /usr/lib/python3.!($python_version) 2>/dev/null
 }
 
 get_broken_perl_pkgs() {
     command -v perl >/dev/null || return
-    perl_version="$(perl -v | grep -Po '\d+' | head -n2 | paste -sd '.\n')"
+    perl_version="$(perl -E 'say $^V =~ /(\d+[.]\d+)/')"
     pacman -Qqo /usr/lib/perl*/!($perl_version) 2>/dev/null
 }
 


### PR DESCRIPTION
Have the perl/python interpreter print their versions instead of parsing output from stderr and stdout.