### PR TITLE
Fix xarg error when file contains \' or \"

### DIFF
--- a/checkrebuild
+++ b/checkrebuild
@@ -30,6 +30,7 @@ filter_executable() {
 get_broken_ldd_pkgs() {
     get_unofficial_pkgs |
     xargs pacman -Qql |
+    sed -E "s/(\"|')/\\\\\1/g"|
     xargs readlink -f |
     filter_executable |
     parallel --will-cite '


### PR DESCRIPTION
There's an uncommon scenario (e.q. mattercontrol,openboard)
when package files contains quotes in their names.
We can fix this by escaping the quote characters.
```sh
$ echo 'test"test' "test'test"|LANG=C xargs file
xargs: unmatched double quote; by default quotes are special to xargs unless you use the -0 option
$ echo 'test"test' "test'test"|sed -E "s/(\"|')/\\\\\1/g"|xargs file
test"test: empty
test'test: empty
```