### PR TITLE
[review] Paranoid mode for `ldd -r`

### DIFF
--- a/checkrebuild
+++ b/checkrebuild
@@ -13,7 +13,7 @@ trap 'rm -rf "$log"' EXIT
 verbose=0
 while getopts "v" OPTION; do
     case $OPTION in
-        v) verbose=1 ;;
+        v) ((verbose+=1)) ;;
         *) exit 1 ;;
     esac
 done
@@ -37,7 +37,6 @@ filter_executable() {
 }
 
 ldd_detect_broken_files() {
-    log="$log/$RANDOM"
     declare -a files
     declare -A resolved_symbols
     declare -A unresolved_symbols
@@ -67,9 +66,9 @@ ldd_detect_broken_files() {
                 fi
             done
             if [ -v unresolved_shared_objects ]; then
-                echo -e "\nldd $file\nunresolved shared objects: ${unresolved_shared_objects[*]}" >> "$log"
-                echo -e "\nldd $file\nunresolved shared objects: ${unresolved_shared_objects[*]}" >&2
-                pacman -Qqo "$file"
+                pkg=$(pacman -Qqo "$file")
+                (( verbose )) && echo -e "$pkg: $file\nunresolved shared objects: ${unresolved_shared_objects[*]}" >&2
+                echo "$pkg"
                 return 0
             fi
         fi
@@ -84,9 +83,9 @@ ldd_detect_broken_files() {
         else
             #report $files as broken if depends on unresolved symbol.
             if [[ -v unresolved_symbols[@] ]] && known_unresolved_symbols=$(grep -f <(IFS=$'\n'; echo "${!unresolved_symbols[*]}") <<<"$undefined_symbols"); then
-                pacman -Qqo "$file"
-                echo -e "\nldd $file\n(cached)unresolved symbols: $known_unresolved_symbols" >> "$log"
-                echo -e "\nldd $file\n(cached)unresolved symbols: $known_unresolved_symbols" >&2
+                pkg=$(pacman -Qqo "$file")
+                (( verbose )) && echo -e "$pkg: $file\n(cached)unresolved symbols: $known_unresolved_symbols" >&2
+                echo "$pkg"
                 return 0
             fi
             #drop cached symbols.
@@ -117,13 +116,13 @@ ldd_detect_broken_files() {
             [ -n "$scanelf_resolve" ] && resolve_symbol_cache system_wide_unresolved_symbols scanelf_resolve deep_unresolved_symbols
             fi
             if [ -v deep_unresolved_symbols ]; then
-                pacman -Qqo "$file"
-                echo -e "\nldd $file\nunresolved symbols: ${deep_unresolved_symbols[*]}" >> "$log"
-                echo -e "\nldd $file\nunresolved symbols: ${deep_unresolved_symbols[*]}" >&2
+                pkg=$(pacman -Qqo "$file")
+                (( verbose )) && echo -e "$pkg: $file\nunresolved symbols: ${deep_unresolved_symbols[*]}" >&2
                 #cache unresolved symbols
                 for symbol in ${deep_unresolved_symbols[*]}; do
                     unresolved_symbols+=(["$symbol"]="$file")
                 done
+                echo "$pkg"
                 return 0
             fi
         fi
@@ -134,9 +133,9 @@ get_broken_ldd_pkgs() {
     export -f get_package_files
     export -f filter_executable
     export -f ldd_detect_broken_files
-    export log
+    export log verbose
     get_unofficial_pkgs |
-    parallel ${_terminal_output:+--bar} --will-cite "echo {}|get_package_files|filter_executable|ldd_detect_broken_files"
+    parallel ${_terminal_output:+--bar}  --will-cite --joblog "$log/rebuild-detector-parallel.log" "echo {}|get_package_files|filter_executable|ldd_detect_broken_files"
 }
 
 get_broken_python_pkgs() {
@@ -166,10 +165,8 @@ get_repo_pkgs() {
 
 join -12 <(get_repo_pkgs | sort -k2) <(get_broken_pkgs) | awk '{ print $2 "\t" $1 }'
 
-if (( verbose )); then
-    for f in "$log"/*; do
-        cat "$f"
-    done
+if (( verbose>1 )); then
+    sort -k4 -n "$log/rebuild-detector-parallel.log"
 fi
 
 exit 0

--- a/checkrebuild
+++ b/checkrebuild
@@ -38,7 +38,9 @@ filter_executable() {
 
 ldd_detect_broken_files() {
     log="$log/$RANDOM"
-    while read -r file; do
+    declare -a files
+    mapfile -t files < <(cat)
+    for file in "${files[@]}"; do
         ldd_resolve=$(ldd -r "$file" 2>/dev/null)
         if missing_shared_objects=$(grep "not found" <<<"$ldd_resolve"); then
             pacman -Qqo "$file"

--- a/checkrebuild
+++ b/checkrebuild
@@ -12,10 +12,11 @@ touch "$log/resolved_symbols"
 trap 'rm -rf "$log"' EXIT
 
 verbose=0
-while getopts "va" OPTION; do
+while getopts "vai:" OPTION; do
     case $OPTION in
         a) system=1 ;;
         v) ((verbose+=1)) ;;
+        i) include+=("$OPTARG") ;;
         *) exit 1 ;;
     esac
 done
@@ -24,8 +25,8 @@ get_unofficial_pkgs() {
     if ((system)); then
         pacman -Qq
     else
-        local_enabled_repos="$(pacconf --repo-list|xargs -I{} bash -c "pacconf --repo={} Server|grep -q -v "file://" && echo {}"|paste -sd ' ' -)"
-        comm -23 <(pacman -Qq | sort) <(eval pacman -Sql "$local_enabled_repos" 2>/dev/null | sort)
+        mapfile -t local_enabled_repos < <(for repo in $(pacconf --repo-list); do pacconf --repo="$repo" Server|grep -q "file://" || [[ "${include[*]}" =~ $repo ]] || echo "$repo"; done)
+        comm -23 <(pacman -Qq | sort) <(pacman -Sql ${local_enabled_repos[@]} 2>/dev/null | sort)
     fi
 }
 

--- a/checkrebuild
+++ b/checkrebuild
@@ -51,6 +51,7 @@ filter_executable() {
 
 ldd_detect_broken_files() {
     declare -a files
+    declare _dirty_cache=0
     declare -A resolved_symbols
     declare -A unresolved_symbols
     mapfile -t files < <(cat)
@@ -63,6 +64,8 @@ ldd_detect_broken_files() {
             for symbol in $(eval echo '${'"$1"'[*]}'); do
                 if scanelf_resolve_symbol=$(eval 'grep -oP "$symbol.*  \K.*" <<<$'"$2"); then
                     resolved_symbols+=(["$symbol"]="$scanelf_resolve_symbol")
+                    #mark cache as dirty.
+                    _dirty_cache=1
                 else
                     eval "$3"'+=("$symbol")'
                 fi
@@ -91,25 +94,26 @@ ldd_detect_broken_files() {
             ldd_resolve=$(LD_LIBRARY_PATH="$library_path" ldd -r "$file" 2>/dev/null)
         fi
         #drop symbol version, not supported by `scanelf`
-        if ! undefined_symbols=$(grep -oP "undefined symbol: \K.*?(?=[\t,])" <<<"$ldd_resolve"); then
-            continue
-        else
+        if undefined_symbols=$(grep -oP "undefined symbol: \K.*?(?=[\t,])" <<<"$ldd_resolve"); then
             #report $files as broken if depends on unresolved symbol.
-            if [[ -s "$log/resolved_symbols" ]]; then
-                flock -s "$log/resolved_symbols" -c "source $log/resolved_symbols"
-            fi
             if [[ -v unresolved_symbols[@] ]] && known_unresolved_symbols=$(grep -f <(IFS=$'\n'; echo "${!unresolved_symbols[*]}") <<<"$undefined_symbols"); then
                 pkg=$(pacman -Qqo "$file")
                 (( verbose )) && echo -e "$pkg: $file\n(cached)unresolved symbols: $known_unresolved_symbols" >&2
                 echo "$pkg"
                 return 0
             fi
+            #read shared cache if exist.
+            if [[ -s "$log/resolved_symbols" ]]; then
+                flock -s "$log/resolved_symbols" -c "source $log/resolved_symbols"
+                #mark cache as clena.
+                _dirty_cache=0
+            fi
             #drop cached symbols.
             if [[ -v resolved_symbols[@] ]]; then
                 undefined_symbols=$(grep -v -f <(IFS=$'\n'; echo "${!resolved_symbols[*]}") <<<"$undefined_symbols")
+                #skip if all symbols in cache.
+                [[ -z "$undefined_symbols" ]] && continue
             fi
-            #skip if all symbols in cache.
-            [[ -z "$undefined_symbols" ]] && continue
             #package wide symbol resolution.
             scanelf_resolve=$(scanelf -qs "+$(tr $'\n' ','<<<"$undefined_symbols"|sed -e 's/,$//' -e 's/,/,\+/g')" "${files[@]}"|grep -f <(echo "${undefined_symbols}"))
             if [ -n "$scanelf_resolve" ]; then
@@ -117,48 +121,65 @@ ldd_detect_broken_files() {
             else
                 mapfile -t local_unresolved_symbols <<<"$undefined_symbols"
             fi
+            if [ -v local_unresolved_symbols ]; then
+                #system wide symbol resolution.
+                scanelf_resolve=$(scanelf -qpls "+$(IFS=','; echo "${local_unresolved_symbols[*]}"|sed -e 's/,$//' -e 's/,/,\+/g')"|grep -f <(IFS=$'\n'; echo "${local_unresolved_symbols[*]}"))
+                if [ -n "$scanelf_resolve" ]; then
+                    resolve_symbol_cache local_unresolved_symbols scanelf_resolve system_wide_unresolved_symbols
+                else
+                    mapfile -t system_wide_unresolved_symbols <<<"$local_unresolved_symbols"
+                fi
+                if [ -v system_wide_unresolved_symbols ]; then
+                #do a deep search.
+                scanelf_resolve=$(scanelf -qRs "+$(IFS=','; echo "${system_wide_unresolved_symbols[*]}"|sed -e 's/,$//' -e 's/,/,\+/g')" /usr/{bin,lib}|grep -f <(IFS=$'\n'; echo "${system_wide_unresolved_symbols[*]}"))
+                [ -n "$scanelf_resolve" ] && resolve_symbol_cache system_wide_unresolved_symbols scanelf_resolve deep_unresolved_symbols
+                fi
+                if [ -v deep_unresolved_symbols ]; then
+                    pkg=$(pacman -Qqo "$file")
+                    (( verbose )) && echo -e "$pkg: $file\nunresolved symbols: ${deep_unresolved_symbols[*]}" >&2
+                    #cache unresolved symbols
+                    for symbol in ${deep_unresolved_symbols[*]}; do
+                        unresolved_symbols+=(["$symbol"]="$file")
+                    done
+                    echo "$pkg"
+                    return 0
+                fi
+            fi
         fi
-        if [ -v local_unresolved_symbols ]; then
-            #system wide symbol resolution.
-            scanelf_resolve=$(scanelf -qpls "+$(IFS=','; echo "${local_unresolved_symbols[*]}"|sed -e 's/,$//' -e 's/,/,\+/g')"|grep -f <(IFS=$'\n'; echo "${local_unresolved_symbols[*]}"))
-            if [ -n "$scanelf_resolve" ]; then
-                resolve_symbol_cache local_unresolved_symbols scanelf_resolve system_wide_unresolved_symbols
+        if ((_dirty_cache)); then
+            #if shared cache empty, export current symbol cache.
+            #if not empty, merge current symbol before exporting.
+            if [[ ! -s "$log/resolved_symbols" ]]; then
+                exec {cache}<"$log/resolved_symbols"
+                flock -x "$cache"
+                declare -p resolved_symbols > "$log/resolved_symbols"
+                exec {cache}<&-
             else
-                mapfile -t system_wide_unresolved_symbols <<<"$local_unresolved_symbols"
+                #create a copy of resolved_symbols for merge.
+                resolved_symbols_declaration=$(declare -p resolved_symbols)
+                eval declare -A "resolved_symbols_copy=${resolved_symbols_declaration#*=}"
+                #local shared cache.
+                exec {cache}<"$log/resolved_symbols"
+                flock -x "$cache"
+                #read shared cache.
+                source "$log/resolved_symbols"
+                #detect new symbols.
+                mapfile -t new_symbols < <(comm -23 <(IFS=$'\n'; echo "${!resolved_symbols_copy[*]}"|sort) <(IFS=$'\n'; echo "${!resolved_symbols[*]}"|sort))
+                if [[ -v new_symbols[@] ]]; then
+                    #append new symbols to shared cache.
+                    for symbol in ${new_symbols[*]}; do
+                        resolved_symbols+=(["$symbol"]="${resolved_symbols_copy["$symbol"]}")
+                    done
+                    #export shared cache.
+                    declare -p resolved_symbols > "$log/resolved_symbols"
+                fi
+                #unlock shared cache.
+                exec {cache}<&-
             fi
-            if [ -v system_wide_unresolved_symbols ]; then
-            #do a deep search.
-            scanelf_resolve=$(scanelf -qRs "+$(IFS=','; echo "${system_wide_unresolved_symbols[*]}"|sed -e 's/,$//' -e 's/,/,\+/g')" /usr/{bin,lib}|grep -f <(IFS=$'\n'; echo "${system_wide_unresolved_symbols[*]}"))
-            [ -n "$scanelf_resolve" ] && resolve_symbol_cache system_wide_unresolved_symbols scanelf_resolve deep_unresolved_symbols
-            fi
-            if [ -v deep_unresolved_symbols ]; then
-                pkg=$(pacman -Qqo "$file")
-                (( verbose )) && echo -e "$pkg: $file\nunresolved symbols: ${deep_unresolved_symbols[*]}" >&2
-                #cache unresolved symbols
-                for symbol in ${deep_unresolved_symbols[*]}; do
-                    unresolved_symbols+=(["$symbol"]="$file")
-                done
-                echo "$pkg"
-                return 0
-            fi
+            #mark cache as clean
+            _dirty_cache=0
         fi
     done
-    if [[ -v resolved_symbols[@] ]]; then
-        resolved_symbols_declaration=$(declare -p resolved_symbols)
-        eval declare -A "resolved_symbols_copy=${resolved_symbols_declaration#*=}"
-        exec {cache}<"$log/resolved_symbols"
-        flock -x "$cache"
-        resolved_symbols=()
-        source "$log/resolved_symbols"
-        mapfile -t new_symbols < <(comm -23 <(IFS=$'\n'; echo "${!resolved_symbols_copy[*]}"|sort) <(IFS=$'\n'; echo "${!resolved_symbols[*]}"|sort))
-        if [[ -v new_symbols[@] ]]; then
-            for symbol in ${new_symbols[*]}; do
-                resolved_symbols+=(["$symbol"]="${resolved_symbols_copy["$symbol"]}")
-            done
-            declare -p resolved_symbols > "$log/resolved_symbols"
-        fi
-        exec {cache}<&-
-    fi
 }
 
 get_broken_ldd_pkgs() {

--- a/checkrebuild
+++ b/checkrebuild
@@ -18,13 +18,13 @@ while getopts "v" OPTION; do
 done
 
 get_unofficial_pkgs() {
-    official_repos="testing core extra community-testing community multilib-testing multilib"
-    comm -23 <(pacman -Qq | sort) <(pacman -Sl $official_repos 2>/dev/null | awk '/\[.*[[:alpha:]]+]$/ {print $2};/\[.*[[:digit:]]+]$/ {print $2}' | sort)
+    local_enabled_repos="$(pacconf --repo-list|paste -sd ' ' -)"
+    comm -23 <(pacman -Qq | sort) <(eval pacman -Sql "$local_enabled_repos" 2>/dev/null | sort)
 }
 
 filter_executable() {
     while read -r file; do
-        [[ -f $file && -x $file ]] && echo $file
+        [[ -f "$file" && -x "$file" ]] &&  echo "$file"
     done
 }
 
@@ -43,13 +43,13 @@ get_broken_ldd_pkgs() {
 get_broken_python_pkgs() {
     command -v python >/dev/null || return
     python_version="$(python3 -c 'import sys; print (sys.version_info.minor)')"
-    pacman -Qqo /usr/lib/python3.!($python_version) 2>/dev/null
+    pacman -Qqo /usr/lib/python3.!("$python_version") 2>/dev/null
 }
 
 get_broken_perl_pkgs() {
     command -v perl >/dev/null || return
     perl_version="$(perl -E 'say $^V =~ /(\d+[.]\d+)/')"
-    pacman -Qqo /usr/lib/perl*/!($perl_version) 2>/dev/null
+    pacman -Qqo /usr/lib/perl*/!("$perl_version") 2>/dev/null
 }
 
 get_broken_pkgs() {
@@ -68,8 +68,7 @@ get_repo_pkgs() {
 join -12 <(get_repo_pkgs | sort -k2) <(get_broken_pkgs) | awk '{ print $2 "\t" $1 }'
 
 if (( verbose )); then
-    cd "$log"
-    for f in *; do
+    for f in "$log"/*; do
         cat "$f"
     done
 fi

--- a/checkrebuild
+++ b/checkrebuild
@@ -40,9 +40,6 @@ filter_executable() {
 ldd_detect_broken_files() {
     declare -a files
     declare -A resolved_symbols
-    if [[ -s "$log/resolved_symbols" ]]; then
-        flock -s "$log/resolved_symbols" -c "source $log/resolved_symbols"
-    fi
     declare -A unresolved_symbols
     mapfile -t files < <(cat)
     resolve_symbol_cache() {
@@ -86,6 +83,9 @@ ldd_detect_broken_files() {
             continue
         else
             #report $files as broken if depends on unresolved symbol.
+            if [[ -s "$log/resolved_symbols" ]]; then
+                flock -s "$log/resolved_symbols" -c "source $log/resolved_symbols"
+            fi
             if [[ -v unresolved_symbols[@] ]] && known_unresolved_symbols=$(grep -f <(IFS=$'\n'; echo "${!unresolved_symbols[*]}") <<<"$undefined_symbols"); then
                 pkg=$(pacman -Qqo "$file")
                 (( verbose )) && echo -e "$pkg: $file\n(cached)unresolved symbols: $known_unresolved_symbols" >&2
@@ -133,12 +133,19 @@ ldd_detect_broken_files() {
     done
     if [[ -v resolved_symbols[@] ]]; then
         resolved_symbols_declaration=$(declare -p resolved_symbols)
-        eval "declare -A resolved_symbols_copy="${resolved_symbols_declaration#*=}
-        sync="$RANDOM"
-        flock -s "$log/resolved_symbols" -c "source $log/resolved_symbols"
-        #test and concat.
-        declare -p resolved_symbols > "$log/$sync"
-        flock "$log/resolved_symbols" -c "cat $log/$sync > $log/resolved_symbols"
+        eval declare -A "resolved_symbols_copy=${resolved_symbols_declaration#*=}"
+        exec {cache}<"$log/resolved_symbols"
+        flock -x "$cache"
+        resolved_symbols=()
+        source "$log/resolved_symbols"
+        mapfile -t new_symbols < <(comm -23 <(IFS=$'\n'; echo "${!resolved_symbols_copy[*]}"|sort) <(IFS=$'\n'; echo "${!resolved_symbols[*]}"|sort))
+        if [[ -v new_symbols[@] ]]; then
+            for symbol in ${new_symbols[*]}; do
+                resolved_symbols+=(["$symbol"]="${resolved_symbols_copy["$symbol"]}")
+            done
+            declare -p resolved_symbols > "$log/resolved_symbols"
+        fi
+        exec {cache}<&-
     fi
 }
 

--- a/checkrebuild
+++ b/checkrebuild
@@ -42,11 +42,25 @@ ldd_detect_broken_files() {
     mapfile -t files < <(cat)
     for file in "${files[@]}"; do
         ldd_resolve=$(ldd -r "$file" 2>/dev/null)
-        if missing_shared_objects=$(grep "not found" <<<"$ldd_resolve"); then
-            pacman -Qqo "$file"
-            echo -e "\nldd $file\n$missing_shared_objects" >> "$log"
-            echo -e "\nldd $file\n$missing_shared_objects" >&2
-            return 0
+        if missing_shared_objects=$(grep -oP "(?<=\t).*?(?= => not found)" <<<"$ldd_resolve"); then
+            for shared_object in $missing_shared_objects; do
+                if shared_object_resolve=$(grep -oP "[^ ]*$shared_object"<<<"${files[*]}"); then
+                    resolved_shared_objects+=("$shared_object_resolve")
+                else
+                    unresolved_shared_objects+=("$shared_object")
+                fi
+            done
+            if [ -v unresolved_shared_objects ]; then
+                echo -e "\nldd $file\nunresolved shared objects: ${unresolved_shared_objects[*]}" >> "$log"
+                echo -e "\nldd $file\nunresolved shared objects: ${unresolved_shared_objects[*]}" >&2
+                pacman -Qqo "$file"
+                return 0
+            fi
+        fi
+        #update $ldd_resolve with $resolved_shared_objects.
+        if [[ -v resolved_shared_objects[@] ]]; then
+            library_path=$(IFS=$'\n'; sort -u<<<"${resolved_shared_objects[*]%/*}"|paste -sd ':')
+            ldd_resolve=$(LD_LIBRARY_PATH="$library_path" ldd -r "$file" 2>/dev/null)
         fi
         if undefined_symbols=$(grep -oP "undefined symbol: \K.*(?=\t)" <<<"$ldd_resolve"); then
             scanelf_resolve=$(scanelf -pls "+$(tr '\n' ','<<<"$undefined_symbols")"|grep -f <(echo "${undefined_symbols}"))

--- a/checkrebuild
+++ b/checkrebuild
@@ -38,32 +38,40 @@ filter_executable() {
 
 ldd_detect_broken_files() {
     log="$log/$RANDOM"
-    ldd_resolve=$(ldd -r "$1" 2>/dev/null)
-    if missing_shared_objects=$(grep "not found" <<<"$ldd_resolve"); then
-        pacman -Qqo "$1"
-        echo -e "\nldd $1\n$missing_shared_objects" >> "$log"
-        return 0
-    fi
-    if undefined_symbols=$(grep -oP "undefined symbol: \K.*(?=\t)" <<<"$ldd_resolve"); then 
-        scanelf_resolve=$(scanelf -pls "+$(tr '\n' ','<<<"$undefined_symbols")"|grep -f <(echo "${undefined_symbols}"))
-        for symbol in $undefined_symbols; do
-            if scanelf_resolve_symbol=$(grep "$symbol" <<<"$scanelf_resolve"); then
-                resolved_symbols+=("$symbol: $scanelf_resolve_symbol")
-            else
-                unresolved_symbols+=("$symbol")
-            fi
-        done
-    fi
-    [ -v unresolved_symbols ] && { pacman -Qqo "$1"; echo -e "\nldd $1\nunresolved symbols: ${unresolved_symbols[*]}" >> "$log"; return 0; }
+    while read -r file; do
+        ldd_resolve=$(ldd -r "$file" 2>/dev/null)
+        if missing_shared_objects=$(grep "not found" <<<"$ldd_resolve"); then
+            pacman -Qqo "$file"
+            echo -e "\nldd $file\n$missing_shared_objects" >> "$log"
+            echo -e "\nldd $file\n$missing_shared_objects" >&2
+            return 0
+        fi
+        if undefined_symbols=$(grep -oP "undefined symbol: \K.*(?=\t)" <<<"$ldd_resolve"); then
+            scanelf_resolve=$(scanelf -pls "+$(tr '\n' ','<<<"$undefined_symbols")"|grep -f <(echo "${undefined_symbols}"))
+            for symbol in $undefined_symbols; do
+                if scanelf_resolve_symbol=$(grep "$symbol" <<<"$scanelf_resolve"); then
+                    resolved_symbols+=("$symbol: $scanelf_resolve_symbol")
+                else
+                    unresolved_symbols+=("$symbol")
+                fi
+            done
+        fi
+        if [ -v unresolved_symbols ]; then
+            pacman -Qqo "$file"
+            echo -e "\nldd $file\nunresolved symbols: ${unresolved_symbols[*]}" >> "$log"
+            echo -e "\nldd $file\nunresolved symbols: ${unresolved_symbols[*]}" >&2
+            return 0
+        fi
+    done
 }
 
 get_broken_ldd_pkgs() {
+    export -f get_package_files
+    export -f filter_executable
     export -f ldd_detect_broken_files
     export log
     get_unofficial_pkgs |
-    get_package_files |
-    filter_executable |
-    parallel ${_terminal_output:+--bar} --will-cite ldd_detect_broken_files
+    parallel ${_terminal_output:+--bar} --will-cite "echo {}|get_package_files|filter_executable|ldd_detect_broken_files"
 }
 
 get_broken_python_pkgs() {

--- a/checkrebuild
+++ b/checkrebuild
@@ -12,16 +12,21 @@ touch "$log/resolved_symbols"
 trap 'rm -rf "$log"' EXIT
 
 verbose=0
-while getopts "v" OPTION; do
+while getopts "va" OPTION; do
     case $OPTION in
+        a) system=1 ;;
         v) ((verbose+=1)) ;;
         *) exit 1 ;;
     esac
 done
 
 get_unofficial_pkgs() {
-    local_enabled_repos="$(pacconf --repo-list|paste -sd ' ' -)"
-    comm -23 <(pacman -Qq | sort) <(eval pacman -Sql "$local_enabled_repos" 2>/dev/null | sort)
+    if ((system)); then
+        pacman -Qq
+    else
+        local_enabled_repos="$(pacconf --repo-list|xargs -I{} bash -c "pacconf --repo={} Server|grep -q -v "file://" && echo {}"|paste -sd ' ' -)"
+        comm -23 <(pacman -Qq | sort) <(eval pacman -Sql "$local_enabled_repos" 2>/dev/null | sort)
+    fi
 }
 
 get_package_files() {

--- a/checkrebuild
+++ b/checkrebuild
@@ -6,6 +6,7 @@
 shopt -s nullglob
 shopt -s extglob
 [ -t 1 ] && declare _terminal_output=1
+[ -t 0 ] || mapfile -t _hook_targets
 
 log="$(mktemp -d)"
 touch "$log/resolved_symbols"
@@ -26,7 +27,11 @@ get_unofficial_pkgs() {
         pacman -Qq
     else
         mapfile -t local_enabled_repos < <(for repo in $(pacconf --repo-list); do pacconf --repo="$repo" Server|grep -q "file://" || [[ "${include[*]}" =~ $repo ]] || echo "$repo"; done)
-        comm -23 <(pacman -Qq | sort) <(pacman -Sql ${local_enabled_repos[@]} 2>/dev/null | sort)
+        if [[ -v _hook_targets[@] ]]; then
+            ( IFS=$'\n'; xargs -I{} pactree -rud1 {}<<<"${_hook_targets[*]}"|sort -u)
+        else
+            pacman -Qq
+        fi|sort|comm -23 - <(eval pacman -Sql "${local_enabled_repos[*]}" 2>/dev/null | sort)
     fi
 }
 

--- a/checkrebuild
+++ b/checkrebuild
@@ -8,6 +8,7 @@ shopt -s extglob
 [ -t 1 ] && declare _terminal_output=1
 
 log="$(mktemp -d)"
+touch "$log/resolved_symbols"
 trap 'rm -rf "$log"' EXIT
 
 verbose=0
@@ -39,6 +40,9 @@ filter_executable() {
 ldd_detect_broken_files() {
     declare -a files
     declare -A resolved_symbols
+    if [[ -s "$log/resolved_symbols" ]]; then
+        flock -s "$log/resolved_symbols" -c "source $log/resolved_symbols"
+    fi
     declare -A unresolved_symbols
     mapfile -t files < <(cat)
     resolve_symbol_cache() {
@@ -127,6 +131,15 @@ ldd_detect_broken_files() {
             fi
         fi
     done
+    if [[ -v resolved_symbols[@] ]]; then
+        resolved_symbols_declaration=$(declare -p resolved_symbols)
+        eval "declare -A resolved_symbols_copy="${resolved_symbols_declaration#*=}
+        sync="$RANDOM"
+        flock -s "$log/resolved_symbols" -c "source $log/resolved_symbols"
+        #test and concat.
+        declare -p resolved_symbols > "$log/$sync"
+        flock "$log/resolved_symbols" -c "cat $log/$sync > $log/resolved_symbols"
+    fi
 }
 
 get_broken_ldd_pkgs() {

--- a/checkrebuild
+++ b/checkrebuild
@@ -40,6 +40,7 @@ ldd_detect_broken_files() {
     log="$log/$RANDOM"
     declare -a files
     declare -A resolved_symbols
+    declare -A unresolved_symbols
     mapfile -t files < <(cat)
     resolve_symbol_cache() {
     #args: $1: name of the missing symbols variable (string|array).
@@ -78,7 +79,16 @@ ldd_detect_broken_files() {
             ldd_resolve=$(LD_LIBRARY_PATH="$library_path" ldd -r "$file" 2>/dev/null)
         fi
         #drop symbol version, not supported by `scanelf`
-        if undefined_symbols=$(grep -oP "undefined symbol: \K.*?(?=[\t,])" <<<"$ldd_resolve"); then
+        if ! undefined_symbols=$(grep -oP "undefined symbol: \K.*?(?=[\t,])" <<<"$ldd_resolve"); then
+            continue
+        else
+            #report $files as broken if depends on unresolved symbol.
+            if [[ -v unresolved_symbols[@] ]] && known_unresolved_symbols=$(grep -f <(IFS=$'\n'; echo "${!unresolved_symbols[*]}") <<<"$undefined_symbols"); then
+                pacman -Qqo "$file"
+                echo -e "\nldd $file\n(cached)unresolved symbols: $known_unresolved_symbols" >> "$log"
+                echo -e "\nldd $file\n(cached)unresolved symbols: $known_unresolved_symbols" >&2
+                return 0
+            fi
             #drop cached symbols.
             if [[ -v resolved_symbols[@] ]]; then
                 undefined_symbols=$(grep -v -f <(IFS=$'\n'; echo "${!resolved_symbols[*]}") <<<"$undefined_symbols")
@@ -110,6 +120,10 @@ ldd_detect_broken_files() {
                 pacman -Qqo "$file"
                 echo -e "\nldd $file\nunresolved symbols: ${deep_unresolved_symbols[*]}" >> "$log"
                 echo -e "\nldd $file\nunresolved symbols: ${deep_unresolved_symbols[*]}" >&2
+                #cache unresolved symbols
+                for symbol in ${deep_unresolved_symbols[*]}; do
+                    unresolved_symbols+=(["$symbol"]="$file")
+                done
                 return 0
             fi
         fi

--- a/checkrebuild
+++ b/checkrebuild
@@ -5,6 +5,7 @@
 
 shopt -s nullglob
 shopt -s extglob
+[ -t 1 ] && declare _terminal_output=1
 
 log="$(mktemp -d)"
 trap 'rm -rf "$log"' EXIT
@@ -34,7 +35,7 @@ get_broken_ldd_pkgs() {
     perl -pe 's/\n/\0/' |
     xargs -0 readlink -f |
     filter_executable |
-    parallel --will-cite '
+    parallel ${_terminal_output:+--bar} --will-cite '
         ldd "{}" 2>/dev/null |
         grep "not found" > >( out="$(cat)"; f="$RANDOM"; [ -n "$out" ] && { echo -e "\nldd {}\n" >> "'$log'/$f"; c++filt "$out" >> "'$log'/$f"; } ) &&
         pacman -Qqo "{}"'

--- a/checkrebuild
+++ b/checkrebuild
@@ -23,6 +23,12 @@ get_unofficial_pkgs() {
     comm -23 <(pacman -Qq | sort) <(eval pacman -Sql "$local_enabled_repos" 2>/dev/null | sort)
 }
 
+get_package_files() {
+    xargs pacman -Qql |
+    perl -pe 's/\n/\0/' |
+    xargs -0 readlink -f
+}
+
 filter_executable() {
     while read -r file; do
         [[ -f "$file" && -x "$file" ]] &&  echo "$file"
@@ -31,9 +37,7 @@ filter_executable() {
 
 get_broken_ldd_pkgs() {
     get_unofficial_pkgs |
-    xargs pacman -Qql |
-    perl -pe 's/\n/\0/' |
-    xargs -0 readlink -f |
+    get_package_files |
     filter_executable |
     parallel ${_terminal_output:+--bar} --will-cite '
         ldd "{}" 2>/dev/null |

--- a/checkrebuild
+++ b/checkrebuild
@@ -195,7 +195,13 @@ get_repo_pkgs() {
     pacman -Qqm | awk '{print "foreign", $0}'
 }
 
-join -12 <(get_repo_pkgs | sort -k2) <(get_broken_pkgs) | awk '{ print $2 "\t" $1 }'
+if [[ "${BASH_SOURCE[-1]}" =~ bashdb ]]
+then 
+    get_package_files<<<"apparmor"|filter_executable|ldd_detect_broken_files|nl
+    get_package_files<<<"ardour"|filter_executable|ldd_detect_broken_files|nl
+    get_package_files<<<"alsa-utils"|filter_executable|ldd_detect_broken_files|nl
+else join -12 <(get_repo_pkgs | sort -k2) <(get_broken_pkgs) | awk '{ print $2 "\t" $1 }'
+fi
 
 if (( verbose>1 )); then
     sort -k4 -n "$log/rebuild-detector-parallel.log"

--- a/checkrebuild
+++ b/checkrebuild
@@ -39,14 +39,22 @@ filter_executable() {
 ldd_detect_broken_files() {
     log="$log/$RANDOM"
     ldd_resolve=$(ldd -r "$1" 2>/dev/null)
-    not_found=$(grep -q "not found" <<<"$ldd_resolve") && { pacman -Qqo "$1"; echo -e "\nldd $1\n$not_found" >> "$log"; exit 0; }
+    if missing_shared_objects=$(grep "not found" <<<"$ldd_resolve"); then
+        pacman -Qqo "$1"
+        echo -e "\nldd $1\n$missing_shared_objects" >> "$log"
+        return 0
+    fi
     if undefined_symbols=$(grep -oP "undefined symbol: \K.*(?=\t)" <<<"$ldd_resolve"); then 
-        c++filt <<<"$undefined_symbols" >> "$log"
+        scanelf_resolve=$(scanelf -pls "+$(tr '\n' ','<<<"$undefined_symbols")"|grep -f <(echo "${undefined_symbols}"))
         for symbol in $undefined_symbols; do
-            scanelf_resolve=$(scanelf -pls +"$symbol") && resolved_symbols+=("$symbol") || unresolved_symbols+=("$symbol: $scanelf_resolve")
+            if scanelf_resolve_symbol=$(grep "$symbol" <<<"$scanelf_resolve"); then
+                resolved_symbols+=("$symbol: $scanelf_resolve_symbol")
+            else
+                unresolved_symbols+=("$symbol")
+            fi
         done
     fi
-    [ -v unresolved_symbols ] && pacman -Qqo "$1"
+    [ -v unresolved_symbols ] && { pacman -Qqo "$1"; echo -e "\nldd $1\nunresolved symbols: ${unresolved_symbols[*]}" >> "$log"; return 0; }
 }
 
 get_broken_ldd_pkgs() {

--- a/checkrebuild
+++ b/checkrebuild
@@ -13,11 +13,12 @@ touch "$log/resolved_symbols"
 trap 'rm -rf "$log"' EXIT
 
 verbose=0
-while getopts "vai:" OPTION; do
+while getopts "vai:d:" OPTION; do
     case $OPTION in
         a) system=1 ;;
         v) ((verbose+=1)) ;;
         i) include+=("$OPTARG") ;;
+        d) [[ $OPTARG == [0-9]* ]] && _depth="$OPTARG" ;;
         *) exit 1 ;;
     esac
 done
@@ -28,7 +29,7 @@ get_unofficial_pkgs() {
     else
         mapfile -t local_enabled_repos < <(for repo in $(pacconf --repo-list); do pacconf --repo="$repo" Server|grep -q "file://" || [[ "${include[*]}" =~ $repo ]] || echo "$repo"; done)
         if [[ -v _hook_targets[@] ]]; then
-            ( IFS=$'\n'; xargs -I{} pactree -rud1 {}<<<"${_hook_targets[*]}"|sort -u)
+            ( IFS=$'\n'; xargs -I{} pactree -rud "${_depth:-1}" {}<<<"${_hook_targets[*]}"|sort -u)
         else
             pacman -Qq
         fi|sort|comm -23 - <(eval pacman -Sql "${local_enabled_repos[*]}" 2>/dev/null | sort)

--- a/checkrebuild
+++ b/checkrebuild
@@ -26,7 +26,7 @@ get_unofficial_pkgs() {
 get_package_files() {
     xargs pacman -Qql |
     perl -pe 's/\n/\0/' |
-    xargs -0 readlink -f
+    xargs -0 -I{} readlink -f "{}"
 }
 
 filter_executable() {

--- a/checkrebuild
+++ b/checkrebuild
@@ -26,7 +26,8 @@ get_unofficial_pkgs() {
 get_package_files() {
     xargs pacman -Qql |
     perl -pe 's/\n/\0/' |
-    xargs -0 -I{} readlink -f "{}"
+    xargs -0 -I{} readlink -f "{}" |
+    sort -u
 }
 
 filter_executable() {

--- a/checkrebuild
+++ b/checkrebuild
@@ -31,7 +31,7 @@ get_package_files() {
 
 filter_executable() {
     while read -r file; do
-        [[ -f "$file" && -x "$file" ]] &&  echo "$file"
+        [[ -f "$file" && -x "$file" ]] && file "$file"|grep -q ELF && echo "$file"
     done
 }
 

--- a/checkrebuild
+++ b/checkrebuild
@@ -41,6 +41,20 @@ ldd_detect_broken_files() {
     declare -a files
     declare -A resolved_symbols
     mapfile -t files < <(cat)
+    resolve_symbol_cache() {
+    #args: $1: name of the missing symbols variable (string|array).
+    #      $2: name of scanelf resolve variable (string).
+    #      $3: name of output array.
+            #clear output variable
+            eval 'unset '"$3"
+            for symbol in $(eval echo '${'"$1"'[*]}'); do
+                if scanelf_resolve_symbol=$(eval 'grep -oP "$symbol.*  \K.*" <<<$'"$2"); then
+                    resolved_symbols+=(["$symbol"]="$scanelf_resolve_symbol")
+                else
+                    eval "$3"'+=("$symbol")'
+                fi
+            done
+    }
     for file in "${files[@]}"; do
         ldd_resolve=$(ldd -r "$file" 2>/dev/null)
         if missing_shared_objects=$(grep -oP "(?<=\t).*?(?= => not found)" <<<"$ldd_resolve"); then
@@ -74,13 +88,7 @@ ldd_detect_broken_files() {
             #package wide symbol resolution.
             scanelf_resolve=$(scanelf -qs "+$(tr $'\n' ','<<<"$undefined_symbols"|sed -e 's/,$//' -e 's/,/,\+/g')" "${files[@]}"|grep -f <(echo "${undefined_symbols}"))
             if [ -n "$scanelf_resolve" ]; then
-                for symbol in $undefined_symbols; do
-                    if scanelf_resolve_symbol=$(grep -oP "$symbol.*  \K.*" <<<"$scanelf_resolve"); then
-                        resolved_symbols+=(["$symbol"]="$scanelf_resolve_symbol")
-                    else
-                        local_unresolved_symbols+=("$symbol")
-                    fi
-                done
+                resolve_symbol_cache undefined_symbols scanelf_resolve local_unresolved_symbols
             else
                 mapfile -t local_unresolved_symbols <<<"$undefined_symbols"
             fi
@@ -88,20 +96,20 @@ ldd_detect_broken_files() {
         if [ -v local_unresolved_symbols ]; then
             #system wide symbol resolution.
             scanelf_resolve=$(scanelf -qpls "+$(IFS=','; echo "${local_unresolved_symbols[*]}"|sed -e 's/,$//' -e 's/,/,\+/g')"|grep -f <(IFS=$'\n'; echo "${local_unresolved_symbols[*]}"))
-            if [ -z "$scanelf_resolve" ]; then
-                scanelf_resolve=$(scanelf -qlRs "+$(IFS=','; echo "${local_unresolved_symbols[*]}"|sed -e 's/,$//' -e 's/,/,\+/g')"|grep -f <(IFS=$'\n'; echo "${local_unresolved_symbols[*]}"))
+            if [ -n "$scanelf_resolve" ]; then
+                resolve_symbol_cache local_unresolved_symbols scanelf_resolve system_wide_unresolved_symbols
+            else
+                mapfile -t system_wide_unresolved_symbols <<<"$local_unresolved_symbols"
             fi
-            for symbol in ${local_unresolved_symbols[*]}; do
-                if scanelf_resolve_symbol=$(grep -oP "$symbol.*  \K.*" <<<"$scanelf_resolve"); then
-                    resolved_symbols+=(["$symbol"]="$scanelf_resolve_symbol")
-                else
-                    system_wide_unresolved_symbols+=("$symbol")
-                fi
-            done
             if [ -v system_wide_unresolved_symbols ]; then
+            #do a deep search.
+            scanelf_resolve=$(scanelf -qRs "+$(IFS=','; echo "${system_wide_unresolved_symbols[*]}"|sed -e 's/,$//' -e 's/,/,\+/g')" /usr/{bin,lib}|grep -f <(IFS=$'\n'; echo "${system_wide_unresolved_symbols[*]}"))
+            [ -n "$scanelf_resolve" ] && resolve_symbol_cache system_wide_unresolved_symbols scanelf_resolve deep_unresolved_symbols
+            fi
+            if [ -v deep_unresolved_symbols ]; then
                 pacman -Qqo "$file"
-                echo -e "\nldd $file\nunresolved symbols: ${system_wide_unresolved_symbols[*]}" >> "$log"
-                echo -e "\nldd $file\nunresolved symbols: ${system_wide_unresolved_symbols[*]}" >&2
+                echo -e "\nldd $file\nunresolved symbols: ${deep_unresolved_symbols[*]}" >> "$log"
+                echo -e "\nldd $file\nunresolved symbols: ${deep_unresolved_symbols[*]}" >&2
                 return 0
             fi
         fi

--- a/checkrebuild
+++ b/checkrebuild
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Detect broken packages that need to be rebuilt
+# vim: ts=4 sw=4 et
 
 shopt -s nullglob
 shopt -s extglob

--- a/checkrebuild
+++ b/checkrebuild
@@ -36,14 +36,26 @@ filter_executable() {
     done
 }
 
+ldd_detect_broken_files() {
+    log="$log/$RANDOM"
+    ldd_resolve=$(ldd -r "$1" 2>/dev/null)
+    not_found=$(grep -q "not found" <<<"$ldd_resolve") && { pacman -Qqo "$1"; echo -e "\nldd $1\n$not_found" >> "$log"; exit 0; }
+    if undefined_symbols=$(grep -oP "undefined symbol: \K.*(?=\t)" <<<"$ldd_resolve"); then 
+        c++filt <<<"$undefined_symbols" >> "$log"
+        for symbol in $undefined_symbols; do
+            scanelf_resolve=$(scanelf -pls +"$symbol") && resolved_symbols+=("$symbol") || unresolved_symbols+=("$symbol: $scanelf_resolve")
+        done
+    fi
+    [ -v unresolved_symbols ] && pacman -Qqo "$1"
+}
+
 get_broken_ldd_pkgs() {
+    export -f ldd_detect_broken_files
+    export log
     get_unofficial_pkgs |
     get_package_files |
     filter_executable |
-    parallel ${_terminal_output:+--bar} --will-cite '
-        ldd "{}" 2>/dev/null |
-        grep "not found" > >( out="$(cat)"; f="$RANDOM"; [ -n "$out" ] && { echo -e "\nldd {}\n" >> "'$log'/$f"; c++filt "$out" >> "'$log'/$f"; } ) &&
-        pacman -Qqo "{}"'
+    parallel ${_terminal_output:+--bar} --will-cite ldd_detect_broken_files
 }
 
 get_broken_python_pkgs() {

--- a/checkrebuild
+++ b/checkrebuild
@@ -39,6 +39,7 @@ filter_executable() {
 ldd_detect_broken_files() {
     log="$log/$RANDOM"
     declare -a files
+    declare -A resolved_symbols
     mapfile -t files < <(cat)
     for file in "${files[@]}"; do
         ldd_resolve=$(ldd -r "$file" 2>/dev/null)
@@ -62,21 +63,47 @@ ldd_detect_broken_files() {
             library_path=$(IFS=$'\n'; sort -u<<<"${resolved_shared_objects[*]%/*}"|paste -sd ':')
             ldd_resolve=$(LD_LIBRARY_PATH="$library_path" ldd -r "$file" 2>/dev/null)
         fi
-        if undefined_symbols=$(grep -oP "undefined symbol: \K.*(?=\t)" <<<"$ldd_resolve"); then
-            scanelf_resolve=$(scanelf -pls "+$(tr '\n' ','<<<"$undefined_symbols")"|grep -f <(echo "${undefined_symbols}"))
-            for symbol in $undefined_symbols; do
-                if scanelf_resolve_symbol=$(grep "$symbol" <<<"$scanelf_resolve"); then
-                    resolved_symbols+=("$symbol: $scanelf_resolve_symbol")
+        #drop symbol version, not supported by `scanelf`
+        if undefined_symbols=$(grep -oP "undefined symbol: \K.*?(?=[\t,])" <<<"$ldd_resolve"); then
+            #drop cached symbols.
+            if [[ -v resolved_symbols[@] ]]; then
+                undefined_symbols=$(grep -v -f <(IFS=$'\n'; echo "${!resolved_symbols[*]}") <<<"$undefined_symbols")
+            fi
+            #skip if all symbols in cache.
+            [[ -z "$undefined_symbols" ]] && continue
+            #package wide symbol resolution.
+            scanelf_resolve=$(scanelf -qs "+$(tr $'\n' ','<<<"$undefined_symbols"|sed -e 's/,$//' -e 's/,/,\+/g')" "${files[@]}"|grep -f <(echo "${undefined_symbols}"))
+            if [ -n "$scanelf_resolve" ]; then
+                for symbol in $undefined_symbols; do
+                    if scanelf_resolve_symbol=$(grep -oP "$symbol.*  \K.*" <<<"$scanelf_resolve"); then
+                        resolved_symbols+=(["$symbol"]="$scanelf_resolve_symbol")
+                    else
+                        local_unresolved_symbols+=("$symbol")
+                    fi
+                done
+            else
+                mapfile -t local_unresolved_symbols <<<"$undefined_symbols"
+            fi
+        fi
+        if [ -v local_unresolved_symbols ]; then
+            #system wide symbol resolution.
+            scanelf_resolve=$(scanelf -qpls "+$(IFS=','; echo "${local_unresolved_symbols[*]}"|sed -e 's/,$//' -e 's/,/,\+/g')"|grep -f <(IFS=$'\n'; echo "${local_unresolved_symbols[*]}"))
+            if [ -z "$scanelf_resolve" ]; then
+                scanelf_resolve=$(scanelf -qlRs "+$(IFS=','; echo "${local_unresolved_symbols[*]}"|sed -e 's/,$//' -e 's/,/,\+/g')"|grep -f <(IFS=$'\n'; echo "${local_unresolved_symbols[*]}"))
+            fi
+            for symbol in ${local_unresolved_symbols[*]}; do
+                if scanelf_resolve_symbol=$(grep -oP "$symbol.*  \K.*" <<<"$scanelf_resolve"); then
+                    resolved_symbols+=(["$symbol"]="$scanelf_resolve_symbol")
                 else
-                    unresolved_symbols+=("$symbol")
+                    system_wide_unresolved_symbols+=("$symbol")
                 fi
             done
-        fi
-        if [ -v unresolved_symbols ]; then
-            pacman -Qqo "$file"
-            echo -e "\nldd $file\nunresolved symbols: ${unresolved_symbols[*]}" >> "$log"
-            echo -e "\nldd $file\nunresolved symbols: ${unresolved_symbols[*]}" >&2
-            return 0
+            if [ -v system_wide_unresolved_symbols ]; then
+                pacman -Qqo "$file"
+                echo -e "\nldd $file\nunresolved symbols: ${system_wide_unresolved_symbols[*]}" >> "$log"
+                echo -e "\nldd $file\nunresolved symbols: ${system_wide_unresolved_symbols[*]}" >&2
+                return 0
+            fi
         fi
     done
 }

--- a/rebuild-detector.hook
+++ b/rebuild-detector.hook
@@ -7,3 +7,4 @@ Target = *
 Description = Checking which packages need to be rebuilt
 Exec = /usr/bin/checkrebuild
 When = PostTransaction
+NeedsTargets

--- a/time.checkrebuild
+++ b/time.checkrebuild
@@ -1,0 +1,129 @@
+#!/bin/bash
+# vim:set ts=2 sw=2 et:
+# shellcheck disable=SC1067
+
+# Options:
+# --flags xxx: pass xxx to checkrebuild
+# --exclude xxx: exclude xxx packages, use perl regex match: e.g. "(perl-wx|python-*)"
+# --shuffle: shuffle packages before parallelization.
+
+[ ! -d .log ] && mkdir .log
+alphabeth=(0 {A..Z})
+
+declare -a stdout
+declare -a stderr
+declare -a script
+declare -a broken_pkgs
+declare -a timing
+declare jobs=$(nproc) #$(($(nproc)/2))
+export COLUMNS
+date=$(date +%F_%H:%M)
+
+function script_mod {
+sed \
+-e "s,parallel ,parallel -j$jobs ," \
+-e '/--joblog/s,--joblog "$log/rebuild-detector-parallel.log",,' \
+-e 's,parallel ,parallel --joblog \"${PWD}/.log/${__compare}_${date}_${hash}_joblog.log\" ,' \
+-e '/declare _terminal_output/s/^.*$/_terminal_output=1/' \
+-e '/--bar/s/${_terminal_output:+--bar}/--bar/'|\
+{ [[ -v _exclude ]] && sed -e '/^get_unofficial_pkgs()/s/$/ {/' -e "/^get_unofficial_pkgs()/,/^}$/s/^}$/}|grep -vP \"$_exclude\"; }/"||cat; }|\
+{ [[ -v _shuffle ]] && sed -e 's,parallel ,parallel --shuf ,' || cat; }
+#-e 's,|xargs -I{} bash -c "pacconf --repo={} Server|grep -q -v "file://" && echo {}",,' \
+}
+
+i=1
+while true; do
+  case "$1" in
+    "") break;;
+    --flags|--flag|-f) _flags="$2"; shift 2;;
+    --exclude|--exc|-e) _exclude="$2"; shift 2;;
+    --shuffle|--shuf|-s) _shuffle=1; shift;;
+    -*) echo "usage: ${0#*/} compare files or commits or a mix of both" >&2 && exit 1;;
+     *) compare+=(["$((i++))"]="$1"); shift;;
+  esac
+done
+
+[[ ! -v compare[@] ]] && compare=([1]="checkrebuild" [2]="$(git rev-parse --short HEAD)")
+[[ ${#compare[*]} == 1 ]] && compare=([1]="checkrebuild" [2]="${compare[1]}")
+
+for i in $(seq 1 ${#compare[*]}); do
+  [[ -x "${compare[$i]}" ]] && { script[$i]="$(script_mod <"${compare[$i]}")"; continue; }
+  git cat-file -e "${compare[$i]}^{commit}" && { script[$i]="$(script_mod < <(git show "${compare[$i]}":checkrebuild))"; continue; }
+  echo "file|commit \"${compare[$i]}\" does not exist" >&2
+  exit 2
+done
+
+for i in $(seq 1 ${#script[*]}); do
+hash=$(md5sum<<<"$RANDOM"|cut -c -6)
+file_stderr="${PWD}/.log/${compare[$i]}_${date}_${hash}_stderr.log"
+file_stdout="${PWD}/.log/${compare[$i]}_${date}_${hash}_stdout.log"
+echo "Execute: ${compare[$i]}" >&2
+__compare="${compare[$i]}"
+export i hash date __compare
+env time bash -c "${script[$i]}" -- "$_flags" 1>"$file_stdout" 2>(tee "$file_stderr" >&2)
+stderr[$i]=$(<"$file_stderr")
+stdout[$i]=$(<"$file_stdout")
+broken_pkgs[$i]=$(expand<<<"${stdout[$i]}")
+timing[$i]=$(<"${PWD}/.log/${compare[$i]}_${date}_${hash}_joblog.log")
+done
+
+pkg_uniq=$(for i in $(seq 1 ${#stdout[*]});do echo "${broken_pkgs["$i"]}"; done|sort -u)
+max_len=$(echo "$pkg_uniq"|awk ' { if ( length > L ) { L=length} }END{ print L}')
+printf "%-${max_len}s" ${compare[*]}; echo
+(IFS=$'\n';for pkg in $pkg_uniq; do 
+for i in $(seq 1 ${#stdout[*]}); do
+printf "%-${max_len}s" "$([[ "${broken_pkgs["$i"]}" =~ $pkg ]] && echo "$pkg" || echo "-")"
+done; echo
+done)
+
+for i in $(seq 1 ${#stdout[*]}); do
+declare -A "stat_$i"
+while IFS=$'\t' read -r seq host start time send recv exit sig comm
+do eval stat_"$i"'+=(["$(grep -oP "echo \K.*?(?=\|)"<<<"$comm")"]="${time##* }")'
+done < <(tail -n +2 <<<"${timing[$i]}")
+done
+
+comm_uniq=$(for i in $(seq 1 ${#stdout[*]});do IFS=$'\n' eval 'echo "${!'stat_"$i"'[*]}"'; done|sort -u)
+max_len=$(echo "$comm_uniq"|awk ' { if ( length > L ) { L=length} }END{ print L}')
+printf "\n%-${max_len}s\n" "test runs:"
+for i in $(seq 1 ${#stdout[*]}); do
+echo -e "${alphabeth[$i]}:\t${compare[$i]}"
+done;
+
+printf "%-${max_len}s" "comparisons:"
+echo -en "\tA"
+for ((i=1;i<${#stdout[*]};i++)); do for ((j=i+1;j<=${#stdout[*]};j++)); do 
+echo -en "\t${alphabeth[$i]}-${alphabeth[$j]}"
+done;done;echo
+
+unset i j
+for ((i=1;i<${#stdout[*]};i++)); do for ((j=i+1;j<=${#stdout[*]};j++)); do 
+  eval declare -A diff_${i}_$j
+  for comm in $comm_uniq; do 
+    eval diff_${i}_$j'+=(["$comm"]=$(bc -l <<<"${'stat_$i'["$comm"]}-${'stat_$j'["$comm"]}"|sed -E "s/^([-]?)\./\10\./g"))'
+  done
+done; done
+
+unset i j
+for comm in $comm_uniq; do 
+printf "\n%${max_len}s" "$comm"
+echo -en "\t${stat_1["$comm"]}"
+for ((i=1;i<${#stdout[*]};i++)); do for ((j=i+1;j<=${#stdout[*]};j++)); do 
+eval 'echo -en "\t${'diff_${i}_$j'["$comm"]}"'
+done; done
+done|LANG=EN_en sort -k 2 -b -n
+
+printf "%-${max_len}s" "comparisons:"
+echo -en "\tA"
+for ((i=1;i<${#stdout[*]};i++)); do for ((j=i+1;j<=${#stdout[*]};j++)); do 
+echo -en "\t${alphabeth[$i]}-${alphabeth[$j]}"
+done;done;echo
+
+printf "\n%${max_len}s\t" "$sum [sec]:"
+echo -en "$(IFS='+'; echo "${stat_1[*]}"|bc)\t"
+for ((i=1;i<${#stdout[*]};i++)); do for ((j=i+1;j<=${#stdout[*]};j++)); do
+echo -en "$(IFS='+' eval 'echo "${'diff_${i}_${j}'[*]}"'|bc)\t"
+done; done;echo #add newline
+
+
+#vimdiff "/dev/fd/${_diff[0]}" "/dev/fd/${_diff[1]}" </dev/tty


### PR DESCRIPTION
`ldd -r` determine possible issues with shared object resolution.
`scanelf -pls` resolve issues from ldd, and report real issues.
This is just a sketch, it need performance improvement by caching `scanelf -pls` output. 
Fix #5 