### PR TITLE
Make package reproducible on arch linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ sign:
 .PHONY: docs
 docs:
 	marked-man -i README.md -o "$(BIN).7"
-	gzip "$(BIN).7"
+	gzip "$(BIN).7" -n
 
 .PHONY: install
 install:


### PR DESCRIPTION
Currently this package is not fully reproducible on arch linux. See the [diffoscope](https://reproducible.archlinux.org/api/v0/builds/584581/diffoscope).
The issue is the recorded timestamp in the gzip header which can easily be ignored with the [no-name](https://wiki.debian.org/ReproducibleBuilds/TimestampsInGzipHeaders) flag for gzip.